### PR TITLE
Fix enum type failed to get real value

### DIFF
--- a/src/Thrifty.Services/Codecs/Internal/EnumThriftCodec.cs
+++ b/src/Thrifty.Services/Codecs/Internal/EnumThriftCodec.cs
@@ -37,11 +37,7 @@ namespace Thrifty.Codecs.Internal
                 }
                 else
                 {
-                    var enumConstants = (T[])Enum.GetValues(_metadata.EnumType);
-                    if (enumValue < enumConstants.Length)
-                    {
-                        return enumConstants[enumValue];
-                    }
+                    return (T)Enum.ToObject(_metadata.EnumType, enumValue);
                 }
             }
             // unknown, throw unknown value exception
@@ -64,7 +60,7 @@ namespace Thrifty.Codecs.Internal
             }
             else
             {
-                enumValue = Array.IndexOf(Enum.GetValues(_metadata.EnumType), enumConstant);
+                enumValue = Convert.ToInt32(enumConstant);
             }
             protocol.WriteI32(enumValue);
         }

--- a/src/Thrifty.Services/Codecs/Internal/EnumThriftCodec.cs
+++ b/src/Thrifty.Services/Codecs/Internal/EnumThriftCodec.cs
@@ -62,6 +62,12 @@ namespace Thrifty.Codecs.Internal
             {
                 enumValue = Convert.ToInt32(enumConstant);
             }
+            if (enumValue < 0)
+            {
+                //see https://thrift.apache.org/docs/idl
+                //An enum creates an enumerated type, with named values. If no constant value is supplied, the value is either 0 for the first element, or one greater than the preceding value for any subsequent element. Any constant value that is supplied must be non-negative.
+                throw new ThriftyException($"Enum {_metadata.EnumType.FullName} cannot be negative {enumValue} for {Enum.GetName(typeof(T), enumConstant)}, it must be non-negative.");
+            }
             protocol.WriteI32(enumValue);
         }
 

--- a/test/Swifty.Tests/Services/Codecs/Internal/EnumThriftCodecTest.cs
+++ b/test/Swifty.Tests/Services/Codecs/Internal/EnumThriftCodecTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Thrifty.Services;
+using Thrifty.Tests.TestModel.Codecs;
+
+using Xunit;
+
+namespace Thrifty.Tests.Services.Codecs.Internal
+{
+    public class EnumThriftCodecTest
+    {
+        [Fact(DisplayName = "EnumThriftCodec enum枚举类型序列化")]
+        public void EnumFielReadAndWritedTest()
+        {
+            var enumStruct = new EnumStruct()
+            {
+                DefaultEnum = DefaultEnum.Node2,
+                ComplexEnum = ComplexEnum.Node1,
+                //ErrorEnum = ErrorEnum.Node1,
+            };
+
+            ThriftSerializer serializer = new ThriftSerializer();
+            var bytes = serializer.Serialize(enumStruct);
+
+            var obj = serializer.Deserialize<EnumStruct>(bytes);
+
+            Assert.NotNull(obj);
+            Assert.Equal(DefaultEnum.Node2, obj.DefaultEnum);
+            Assert.Equal(ComplexEnum.Node1, obj.ComplexEnum);
+        }
+    }
+}

--- a/test/Swifty.Tests/TestModel/Codecs/EnumStruct.cs
+++ b/test/Swifty.Tests/TestModel/Codecs/EnumStruct.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Thrifty.Tests.TestModel.Codecs
+{
+    [ThriftStruct("enumstruct")]
+    public class EnumStruct
+    {
+        [ThriftField(1)]
+        public DefaultEnum DefaultEnum { get; set; }
+        [ThriftField(2)]
+        public ComplexEnum ComplexEnum { get; set; }
+        //[ThriftField(3)]
+        //public ErrorEnum ErrorEnum { get; set; }
+    }
+
+    public enum DefaultEnum
+    {
+        Node1,
+        Node2,
+        Node3
+    }
+
+    public enum ComplexEnum
+    {
+        Node1 = 85,
+        Node2 = 66,
+        Node3 = 13
+    }
+
+    public enum ErrorEnum
+    {
+        Node1 = -22,
+        Node2 = -20,
+        Node3 = 5,
+    }
+}


### PR DESCRIPTION
Fix the problem of `Enum * does not have a value for *` caused by discontinuous enumeration type values.

The current pr may involve core code. 
I haven't done much testing and correlation checking. 
The author should confirm by himself